### PR TITLE
Reference assets absolutely

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -24,6 +24,6 @@
 
 {% block stylesheets %}
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link rel="stylesheet" href="bundles/os2displayadmin/assets/build/styles.min.css">
-  <link rel="stylesheet" href="bundles/os2displayadmin/css/styleguide.css">
+  <link rel="stylesheet" href="{{ asset('bundles/os2displayadmin/assets/build/styles.min.css') }}">
+  <link rel="stylesheet" href="{{ asset('bundles/os2displayadmin/css/styleguide.css') }}">
 {% endblock %}


### PR DESCRIPTION
This will better support eg. the reset-page that is placed under /resetting/reset but still use the main layout template.

I'm unclear whether there is any need for the current relative reference?