### PR TITLE
Only display the add role modal if the user has admin privileges

### DIFF
--- a/Resources/public/apps/adminApp/user/admin-user.html
+++ b/Resources/public/apps/adminApp/user/admin-user.html
@@ -57,7 +57,7 @@
     </article>
     <article class="grid--item">
       <box heading="{{ 'role.heading' | translate }}">
-        <div class="button-icon-link has-spacing-after" ng-click="showAddRoleModal()" ng-if="baseCanUpdate(user)">
+        <div class="button-icon-link has-spacing-after" ng-click="showAddRoleModal()" ng-if="baseCanUpdateRoles(user)">
           <i class="icon-rounded material-icons">security</i>
           <span class="button-text has-spacing-before">{{ 'common.action.add_role' | translate }}</span>
         </div>

--- a/Resources/public/apps/adminApp/user/admin-user.html
+++ b/Resources/public/apps/adminApp/user/admin-user.html
@@ -57,7 +57,7 @@
     </article>
     <article class="grid--item">
       <box heading="{{ 'role.heading' | translate }}">
-        <div class="button-icon-link has-spacing-after" ng-click="showAddRoleModal()" ng-if="baseCanUpdateRoles(user)">
+        <div class="button-icon-link has-spacing-after" ng-click="showAddRoleModal()" ng-if="baseCanUpdateRoles(baseCurrentUser)">
           <i class="icon-rounded material-icons">security</i>
           <span class="button-text has-spacing-before">{{ 'common.action.add_role' | translate }}</span>
         </div>

--- a/Resources/public/apps/adminApp/user/adminUserController.js
+++ b/Resources/public/apps/adminApp/user/adminUserController.js
@@ -29,18 +29,25 @@ angular.module('adminApp').controller('AdminUserController', [
     var addRoleToDisplayList = function addRoleToDisplayList(key, role) {
       var actions = [];
 
-      if ($scope.baseCanUpdate($scope.user)) {
+      // Determine actions the user is allowed to perform.
+      if ($scope.baseCanUpdateRoles($scope.baseCurrentUser)) {
         actions.push({
           title: $translate('user.action.remove_role'),
           click: $scope.removeRoleFromUser,
           entity: key
         });
       }
+
       var newRole = {
         id: key,
-        title: role,
-        actions: actions
+        title: role
       };
+
+      // We only add the actions if they are actually there.
+      if (actions.length > 0) {
+        newRole.actions = actions;
+      }
+
       $scope.userRoles.push(newRole);
     };
 

--- a/Resources/public/apps/mainModule/controller/baseController.js
+++ b/Resources/public/apps/mainModule/controller/baseController.js
@@ -63,6 +63,16 @@ angular.module('mainModule').controller('BaseController', ['$scope', 'userServic
     };
 
     /**
+     * Can the entity update roles?
+     *
+     * @param entity
+     * @return {*}
+     */
+    $scope.baseCanUpdateRoles = function baseCanUpdateRoles(entity) {
+      return hasPermission(entity, 'can_update_roles');
+    };
+
+    /**
      * Can the entity be deleted?
      *
      * @param entity


### PR DESCRIPTION
This PR hides the edit button for the role-list if the user does not have the proper role. It does this based on a permission exposed via https://github.com/os2display/core-bundle/pull/5 and thus there is a dependency on that PR.