### PR TITLE
Print the error-message and not a stacktrace on login error

### DIFF
--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -22,7 +22,7 @@
               </div>
               {% block sonata_user_login_error %}
                 {% if error %}
-                  <div class="login--alert">{{ error|trans({}, 'FOSUserBundle') }}</div>
+                  <div class="login--alert">{{ error.messageKey|trans({}, 'FOSUserBundle') }}</div>
                 {% endif %}
               {% endblock %}
 


### PR DESCRIPTION
After the latest symfony upgrade error went from a string to an exception, we had to make this modification to avoid printing a stacktrace on the login-page.