### PR TITLE
Fix errors on user reset form after symfony upgrade

### DIFF
--- a/Resources/views/Resetting/reset_content.html.twig
+++ b/Resources/views/Resetting/reset_content.html.twig
@@ -5,14 +5,13 @@
       <div class="grid--inner">
         <article class="grid--item">
           <article class="box">
-            <form action="{{ path('fos_user_resetting_reset', {'token': token}) }}" {{ form_enctype(form) }}
-                  method="POST" class="fos_user_resetting_reset">
+            {{ form_start(form, {'method': 'post', 'action': path('fos_user_resetting_reset', {'token': token}), 'attr': {'class': 'fos_user_resetting_reset'}}) }}
               <h2 class="heading-has-spacing-after">Skift kodeord</h2>
               <div class="box--inner">
                 <div class="forms-field">
                   <label for="forms_label_id" class="forms-label">Nyt kodeord</label>
-                  {{ form_widget(form.new.first, { 'attr': {'class': 'forms-base forms-password'} }) }}
-                  {% for error in form.new.first.vars.errors %}
+                  {{ form_widget(form, { 'attr': {'class': 'forms-base forms-password'} }) }}
+                  {% for error in form.vars.errors %}
                     <div class="message">
                       <div class="message--inner is-inline-error">
                         <div class="message--content">
@@ -24,8 +23,8 @@
                 </div>
                 <div class="forms-field">
                   <label for="forms_label_id" class="forms-label">Gentag kodeord</label>
-                  {{ form_widget(form.new.second, { 'attr': {'class': 'forms-base forms-password'} }) }}
-                  {% for error in form.new.second.vars.errors %}
+                  {{ form_widget(form, { 'attr': {'class': 'forms-base forms-password'} }) }}
+                  {% for error in form.vars.errors %}
                     <div class="message">
                       <div class="message--inner is-inline-error">
                         <div class="message--content">
@@ -41,7 +40,7 @@
                 </div>
                 {{ form_rest(form) }}
               </div>
-            </form>
+            {{ form_end(form) }}
           </article>
         </article>
       </div>


### PR DESCRIPTION
I was testing the user creation flow and was getting `Unknown "form_enctype" function` Twig error, when using the reset link to the reset form in the mail (see screenshot below).

After investigating this seems to be related to symfony upgrade: 

https://stackoverflow.com/a/37816982

#### Error

![registration-error](https://user-images.githubusercontent.com/5011234/67472537-87a48200-f651-11e9-88e6-c1dcf035064c.PNG)

#### After fix

![registration-no-error](https://user-images.githubusercontent.com/5011234/67472561-91c68080-f651-11e9-9fb3-b40fd8e15fb1.PNG)

![registration-errors-working](https://user-images.githubusercontent.com/5011234/67472569-9428da80-f651-11e9-8962-feac898f6777.PNG)
